### PR TITLE
Maintenance/dependency upgrade

### DIFF
--- a/packages/target/CHANGELOG.md
+++ b/packages/target/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.4.0
+
+Features:
+
+- Upgrade `analyzer` dependency to `^6.2.0`.
+
 ## 0.3.0
 
 Features:

--- a/packages/target/pubspec.yaml
+++ b/packages/target/pubspec.yaml
@@ -1,12 +1,12 @@
 name: target
 description: Functional domain modeling in Dart.
-version: 0.2.2
+version: 0.4.0
 repository: https://github.com/callius/target-dart/tree/main/packages/target
 issue_tracker: https://github.com/callius/target-dart/issues
 homepage: https://github.com/callius/target-dart
 
 environment:
-  sdk: '>=3.0.5 <4.0.0'
+  sdk: '>=3.1.1 <4.0.0'
 
 dependencies:
   collection: ^1.17.1

--- a/packages/target_annotation/CHANGELOG.md
+++ b/packages/target_annotation/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.4.0
+
+Features:
+
+- Upgrade `analyzer` dependency to `^6.2.0`.
+
 ## 0.3.0
 
 Features:

--- a/packages/target_annotation/pubspec.yaml
+++ b/packages/target_annotation/pubspec.yaml
@@ -1,12 +1,12 @@
 name: target_annotation
 description: Functional domain modeling in Dart.
-version: 0.2.2
+version: 0.4.0
 repository: https://github.com/callius/target-dart/tree/main/packages/target_annotation
 issue_tracker: https://github.com/callius/target-dart/issues
 homepage: https://github.com/callius/target-dart
 
 environment:
-  sdk: '>=3.0.5 <4.0.0'
+  sdk: '>=3.1.1 <4.0.0'
 
 dependencies:
   collection: ^1.17.1

--- a/packages/target_annotation_processor/CHANGELOG.md
+++ b/packages/target_annotation_processor/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.4.0
+
+Features:
+
+- Upgrade `analyzer` dependency to `^6.2.0`.
+
 ## 0.3.0
 
 Features:

--- a/packages/target_annotation_processor/pubspec.yaml
+++ b/packages/target_annotation_processor/pubspec.yaml
@@ -1,22 +1,22 @@
 name: target_annotation_processor
 description: Functional domain modeling in Dart.
-version: 0.2.2
+version: 0.4.0
 repository: https://github.com/callius/target-dart/tree/main/packages/target_annotation_processor
 issue_tracker: https://github.com/callius/target-dart/issues
 homepage: https://github.com/callius/target-dart
 
 environment:
-  sdk: '>=3.0.5 <4.0.0'
+  sdk: '>=3.1.1 <4.0.0'
 
 dependencies:
-  analyzer: ^5.13.0
-  build: ^2.4.0
-  code_builder: ^4.5.0
+  analyzer: ^6.2.0
+  build: ^2.4.1
+  code_builder: ^4.6.0
   collection: ^1.17.1
-  dart_style: ^2.3.1
+  dart_style: ^2.3.2
   dartz: ^0.10.1
   equatable: ^2.0.5
-  source_gen: ^1.3.2
+  source_gen: ^1.4.0
   target:
     git:
       url: https://github.com/callius/target-dart
@@ -35,7 +35,7 @@ dependencies:
 
 dev_dependencies:
   build_runner: null
-  build_test: ^2.1.7
+  build_test: ^2.2.0
   lint: ^2.1.2
-  source_gen_test: ^1.0.5
+  source_gen_test: ^1.0.6
   test: null

--- a/packages/target_annotation_processor/pubspec.yaml
+++ b/packages/target_annotation_processor/pubspec.yaml
@@ -21,17 +21,17 @@ dependencies:
     git:
       url: https://github.com/callius/target-dart
       path: packages/target
-      ref: v0.3.0
+      ref: v0.4.0
   target_annotation:
     git:
       url: https://github.com/callius/target-dart
       path: packages/target_annotation
-      ref: v0.3.0
+      ref: v0.4.0
   target_extension:
     git:
       url: https://github.com/callius/target-dart
       path: packages/target_extension
-      ref: v0.3.0
+      ref: v0.4.0
 
 dev_dependencies:
   build_runner: null

--- a/packages/target_extension/CHANGELOG.md
+++ b/packages/target_extension/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.4.0
+
+Features:
+
+- Upgrade `analyzer` dependency to `^6.2.0`.
+
 ## 0.3.0
 
 Features:

--- a/packages/target_extension/pubspec.yaml
+++ b/packages/target_extension/pubspec.yaml
@@ -1,12 +1,12 @@
 name: target_extension
 description: Extensions for functional domain modeling in Dart.
-version: 0.2.2
+version: 0.4.0
 repository: https://github.com/callius/target-dart/tree/main/packages/target_extension
 issue_tracker: https://github.com/callius/target-dart/issues
 homepage: https://github.com/callius/target-dart
 
 environment:
-  sdk: '>=3.0.5 <4.0.0'
+  sdk: '>=3.1.1 <4.0.0'
 
 dependencies:
   collection: ^1.17.1


### PR DESCRIPTION
Upgrade `analyzer` dependency to `^6.2.0`.
Bump versions to `0.4.0`.